### PR TITLE
Added CI workflow builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,20 @@
+name: node build
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    name: Node 18 build
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: npm ci # install dependencies
+      - run: npm run build # compile typescript
+      - run: npm run lint # run eslint
+      - run: npm run prettier  # run prettier
+#      - run: npm test # commented out as tests are not added to the repo yet - tests should be added in the future

--- a/.github/workflows/push-to-ecr-rc.yml
+++ b/.github/workflows/push-to-ecr-rc.yml
@@ -1,0 +1,26 @@
+name: Push RC to ECR
+
+on:
+  push:
+    tags:
+      - 'v[0-9][0-9]?[0-9]?.[0-9][0-9]?[0-9]?.[0-9][0-9]?[0-9]?-rc.[0-9][0-9]?[0-9]?'
+
+env:
+  CONTAINER_NAME: medrunner-portal:${{ github.ref_name }}
+  REGION: us-east-1
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - run: docker build --tag ${{ env.CONTAINER_NAME }} .
+      - name: Push to ECR
+        id: ecr
+        uses: jwalton/gh-ecr-push@v1
+        with:
+          access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          region: ${{ env.REGION }}
+          image: ${{ env.CONTAINER_NAME }}

--- a/.github/workflows/push-to-ecr.yml
+++ b/.github/workflows/push-to-ecr.yml
@@ -1,0 +1,26 @@
+name: Push to ECR
+
+on:
+  push:
+    tags:
+      - 'v[0-9][0-9]?[0-9]?.[0-9][0-9]?[0-9]?.[0-9][0-9]?[0-9]?'
+
+env:
+  CONTAINER_NAME: medrunner-portal:${{ github.ref_name }}
+  REGION: us-west-2
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - run: docker build --tag ${{ env.CONTAINER_NAME }} .
+      - name: Push to ECR
+        id: ecr
+        uses: jwalton/gh-ecr-push@v1
+        with:
+          access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          region: ${{ env.REGION }}
+          image: ${{ env.CONTAINER_NAME }}


### PR DESCRIPTION
`node build` should run on every build

`Push RC to ECR` runs on tags matching `vX.Y.Z-rc.A` and creates an image in the dev environment

`Push to ECR` runs on tags matching `vX.Y.Z` and creates an image in prod