### PR TITLE
CP-100 Fix login window resize epilepsy party

### DIFF
--- a/src/components/adequateLogInScreen/AxisAlignedBoundingBox.ts
+++ b/src/components/adequateLogInScreen/AxisAlignedBoundingBox.ts
@@ -1,0 +1,17 @@
+import type Vector2 from "@/components/adequateLogInScreen/Vector2";
+
+export default class AxisAlignedBoundingBox {
+    public constructor(private readonly min: Vector2, private readonly max: Vector2) {}
+
+    public get Min() {
+        return this.min;
+    }
+
+    public get Max() {
+        return this.max;
+    }
+
+    public get Area() {
+        return (this.Max.X - this.Min.X) * (this.Max.Y - this.Min.Y);
+    }
+}

--- a/src/components/adequateLogInScreen/Star.ts
+++ b/src/components/adequateLogInScreen/Star.ts
@@ -1,0 +1,33 @@
+import type StarProperties from "@/components/adequateLogInScreen/stars/StarProperties";
+
+export default class Star {
+    public constructor(private x: number, private y: number, private z: number, private readonly properties: StarProperties) {}
+
+    public get X(): number {
+        return this.x;
+    }
+
+    public set X(value: number) {
+        this.x = value;
+    }
+
+    public get Y(): number {
+        return this.y;
+    }
+
+    public set Y(value: number) {
+        this.y = value;
+    }
+
+    public get Z(): number {
+        return this.z;
+    }
+
+    public set Z(value: number) {
+        this.z = value;
+    }
+
+    public get Properties(): StarProperties {
+        return this.properties;
+    }
+}

--- a/src/components/adequateLogInScreen/Vector2.ts
+++ b/src/components/adequateLogInScreen/Vector2.ts
@@ -1,0 +1,11 @@
+export default class Vector2 {
+    public constructor(private readonly x: number, private readonly y: number) {}
+
+    public get X() {
+        return this.x;
+    }
+
+    public get Y() {
+        return this.y;
+    }
+}

--- a/src/components/adequateLogInScreen/stars/StarClass.ts
+++ b/src/components/adequateLogInScreen/stars/StarClass.ts
@@ -1,0 +1,88 @@
+import type StarProperties from "@/components/adequateLogInScreen/stars/StarProperties";
+
+class StarClass {
+    constructor(
+        private readonly color: string,
+        private readonly minRadius: number,
+        private readonly maxRadius: number,
+        private readonly minLuminosity: number,
+        private readonly maxLuminosity: number,
+    ) {}
+
+    public generate(): StarProperties {
+        const color = this.color;
+        const radius = Math.random() * (this.maxRadius - this.minRadius) + this.minRadius;
+        const luminosity = Math.random() * (this.maxLuminosity - this.minLuminosity) + this.minLuminosity;
+
+        return {
+            color,
+            edgeColor: AdjustShadeRgb(-0.4, color),
+            radius,
+            luminosity,
+        };
+    }
+}
+
+// yup https://stackoverflow.com/a/13542669
+// I did my best to make it readable
+export function AdjustShadeRgb(amount: number, inStr: string): string {
+    const [r, g, b, a] = inStr.split(",");
+    const amountIsNegative = amount < 0;
+    const base = amountIsNegative ? 0 : amount * 255 ** 2;
+    const scalar = 1 - Math.abs(amount);
+    return (
+        "rgb" +
+        (a ? "a(" : "(") +
+        Math.round((scalar * parseInt(r[3] == "a" ? r.slice(5) : r.slice(4)) ** 2 + base) ** 0.5) +
+        "," +
+        Math.round((scalar * parseInt(g) ** 2 + base) ** 0.5) +
+        "," +
+        Math.round((scalar * parseInt(b) ** 2 + base) ** 0.5) +
+        (a ? "," + a : ")")
+    );
+}
+
+// data from https://en.wikipedia.org/wiki/Stellar_classification
+const typeOStar = new StarClass("rgb(146,181,255)", 6.6, 10, 30000, 50000); // 0.000003%
+const typeBStar = new StarClass("rgb(162,192,255)", 1.8, 6.6, 25, 30000); // 0.12%
+const typeAStar = new StarClass("rgb(213,224,255)", 1.4, 1.8, 5, 25); // 0.61%
+const typeFStar = new StarClass("rgb(249,245,255)", 1.15, 1.4, 1.5, 5); // 3%
+const typeGStar = new StarClass("rgb(255,237,227)", 0.96, 1.15, 0.6, 1.5); // 7.6%
+const typeKStar = new StarClass("rgb(255,218,181)", 0.7, 0.96, 0.08, 0.6); // 12%
+const typeMStar = new StarClass("rgb(255,181,108)", 0.5, 0.7, 0.05, 0.08); // 76%
+
+function randomStarClass(): StarClass {
+    const r = Math.random();
+    if (r < 0.76) {
+        return typeMStar;
+    }
+
+    if (r < 0.88) {
+        return typeKStar;
+    }
+
+    if (r < 0.956) {
+        return typeGStar;
+    }
+
+    if (r < 0.986) {
+        return typeFStar;
+    }
+
+    // kind of random from here on up
+    if (r < 0.995) {
+        return typeAStar;
+    }
+
+    if (r < 0.9985) {
+        return typeBStar;
+    }
+
+    return typeOStar;
+}
+
+export function randomStar(): StarProperties {
+    const starClass = randomStarClass();
+
+    return starClass.generate();
+}

--- a/src/components/adequateLogInScreen/stars/StarProperties.ts
+++ b/src/components/adequateLogInScreen/stars/StarProperties.ts
@@ -1,0 +1,6 @@
+export default interface StarProperties {
+    color: string;
+    edgeColor: string;
+    radius: number;
+    luminosity: number;
+}


### PR DESCRIPTION
### Changes
- Adjusted culling so the field doesn't have to regenerate on window resize
- Adjusted star colors, sizes, and luminosity based on real-world values
- Added glowing effect to more luminous stars
- Star colors are now a gradient, being whiter in the middle and closer to their truer color at the edges
- Stars get whiter as their Z value increases
- Adjusted star velocity to increase exponentially as Z value increases
- New stars are always generated at the minimum Z value

### Known issues
Performance is _ok_ but not great. Increasing the density of the star field seemed to result in a greater performance hit. This seems partially due to rendering the shadow blur for more luminous stars. Adjust the divisor in `expectedStarCount()` to play with this.

`context.globalAlpha` didn't seem to work for me at all, but I've left the code present in hopes that someone else might be able to get it working. Some stars still "pop in" when they could maybe fade in instead.

### Before
![firefox_w4jdEDh0jk](https://github.com/medrunner-services/Client-Portal/assets/30303272/b45ddace-2cc3-4ac0-a766-719f8fbf02b3)

### After
![firefox_oPjU0g6DSz](https://github.com/medrunner-services/Client-Portal/assets/30303272/1dc9be8d-afc7-431f-a569-76604b06a628)
